### PR TITLE
Contribute to existing loggers if present rather than clearing

### DIFF
--- a/py_tests/test_fusion.py
+++ b/py_tests/test_fusion.py
@@ -2076,8 +2076,9 @@ def test_fusion_init_logging_enabled_to_stdout_and_file(credentials: FusionCrede
     Fusion(credentials=credentials, enable_logging=True, log_path=log_path)
 
     # Ensure the logger is configured with both handlers
-    assert any(isinstance(handler, logging.StreamHandler) for handler in logger.handlers)
-    assert any(isinstance(handler, logging.FileHandler) for handler in logger.handlers)
+    assert any(type(handler) is logging.StreamHandler for handler in logger.handlers)
+    assert any(type(handler) is logging.FileHandler for handler in logger.handlers)
+    assert not any(type(handler) is logging.NullHandler for handler in logger.handlers)
 
     # Verify the log file exists
     log_file = log_path / "fusion_sdk.log"
@@ -2087,17 +2088,41 @@ def test_fusion_init_logging_enabled_to_stdout_and_file(credentials: FusionCrede
 
 
 def test_fusion_init_logging_disabled(credentials: FusionCredentials) -> None:
+    # Clear logger handlers to avoid contamination
+    logger.handlers.clear()
+
+    # Create the Fusion object with logging disabled
+    Fusion(credentials=credentials, enable_logging=False)
+
+    # No additional handlers should be added
+    assert any(type(handler) is logging.StreamHandler for handler in logger.handlers)
+    assert all(type(handler) is not logging.FileHandler for handler in logger.handlers)
+    assert not any(type(handler) is logging.NullHandler for handler in logger.handlers)
+
+    # Clean up
+    logger.handlers.clear()
+
+
+def test_fusion_preserves_existing_handlers(credentials: FusionCredentials) -> None:
+    logger.handlers.clear()
+    custom_handler = logging.StreamHandler()
+    logger.addHandler(custom_handler)
+
+    Fusion(credentials=credentials, enable_logging=False)
+
+    assert logger.handlers == [custom_handler]
+    logger.handlers.clear()
+
+
+def test_fusion_adds_streamhandler_when_no_handlers(credentials: FusionCredentials) -> None:
     logger.handlers.clear()
 
     Fusion(credentials=credentials, enable_logging=False)
 
-    assert any(isinstance(handler, logging.StreamHandler) for handler in logger.handlers)
-    assert all(not isinstance(handler, logging.FileHandler) for handler in logger.handlers)
+    assert len(logger.handlers) == 1
+    assert type(logger.handlers[0]) is logging.StreamHandler
 
     logger.handlers.clear()
-
-
-
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyfusion37"
-version = "0.0.5"
+version = "0.0.6-dev0"
 description = "JPMC Fusion Developer Tools"
 homepage = "https://github.com/jpmorganchase/fusion-3.7"
 readme = "README.md"

--- a/src/fusion/__init__.py
+++ b/src/fusion/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = "Fusion Devs"
 __email__ = "fusion_developers@jpmorgan.com"
-__version__ = "0.0.5"
+__version__ = "0.0.6-dev0"
 
 from .fusion import Fusion  # Import the core Fusion class
 

--- a/src/fusion/fusion.py
+++ b/src/fusion/fusion.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.addHandler(logging.NullHandler())
 VERBOSE_LVL = 25
 
 
@@ -124,27 +126,28 @@ class Fusion:
         self.download_folder = download_folder
         Path(download_folder).mkdir(parents=True, exist_ok=True)
 
-        # Always log to stdout, conditionally to file
-        if logger.hasHandlers():
-            logger.handlers.clear()
-
         logging.addLevelName(VERBOSE_LVL, "VERBOSE")
+        logger.setLevel(log_level)
+        if not logger.handlers:
+            logger.addHandler(logging.NullHandler())
+
         formatter = logging.Formatter(
             "%(asctime)s.%(msecs)03d %(name)s:%(levelname)s %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
 
-        # Always add stdout handler
-        stdout_handler = logging.StreamHandler(sys.stdout)
-        stdout_handler.setFormatter(formatter)
-        logger.addHandler(stdout_handler)
-        logger.setLevel(log_level)
-
-        # Optionally add file handler
-        if enable_logging:
+        if enable_logging and not any(type(h) is logging.FileHandler for h in logger.handlers):
             file_handler = logging.FileHandler(filename=f"{log_path}/fusion_sdk.log")
             file_handler.setFormatter(formatter)
             logger.addHandler(file_handler)
+
+        if not any(type(h) is logging.StreamHandler for h in logger.handlers):
+            stdout_handler = logging.StreamHandler(sys.stdout)
+            stdout_handler.setFormatter(formatter)
+            logger.addHandler(stdout_handler)
+
+        if len(logger.handlers) > 1:
+            logger.handlers = [h for h in logger.handlers if type(h) is not logging.NullHandler]
 
         if isinstance(credentials, FusionCredentials):
             self.credentials = credentials


### PR DESCRIPTION
Currently if a user wants to use fusion within their application or library they are forced to use fusions loggers. This is because fusion clears existing loggers globally before adding its own, to address this issue I've added fusion's logging to the existing loggers if present.